### PR TITLE
Use proper ListContainsId method to determine admin privileges when using Vanity commands

### DIFF
--- a/Vanity/ServerExecution.cs
+++ b/Vanity/ServerExecution.cs
@@ -40,7 +40,7 @@ public class ServerExecution
     {
       return false;
     }
-    if (rpc != null && !zNet.m_adminList.Contains(rpc.GetSocket().GetHostName()))
+    if (rpc != null && !zNet.ListContainsId(zNet.m_adminList, rpc.GetSocket().GetHostName()))
     {
       Console.instance.AddString("Unauthorized to set vanity.");
       return false;


### PR DESCRIPTION
When Vanity is installed on a dedicated server and a server admin attempts to run a Vanity command they're notified that they aren't authorized to modify the Vanity configuration, despite their SteamID64 being present in the `adminlist.txt` file. This is probably because of the game now prepending additional data like "playfab/[...]" or "Steam_[...]" to the `ZRpc`'s remote hostname. 

The game provides a method `ZNet.ListContainsId` which preprocesses the host name beforehand, presumably to extract the actual admin's SteamID64, but Vanity doesn't use this method and instead directly checks if the admin list contains the remote player's hostname. This pull request changes the admin list checking logic to use the proper method.

I have tested this change locally on a dedicated server and confirmed that it works as intended, compared to the current main commit.